### PR TITLE
Fix compilation errors in GCC 13 and correct epoll_wait usage

### DIFF
--- a/src/util/epoller.cc
+++ b/src/util/epoller.cc
@@ -107,7 +107,7 @@ void Epoller::poll(const int timeout_ms)
   do_deregister();
 
   int nfds = check_syscall(
-    epoll_wait(epfd_, event_list, sizeof(event_list), timeout_ms));
+    epoll_wait(epfd_, event_list, MAX_EVENTS, timeout_ms));
 
   for (int i = 0; i < nfds; i++) {
     int fd = event_list[i].data.fd;

--- a/src/util/file_descriptor.hh
+++ b/src/util/file_descriptor.hh
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <string_view>
+#include <cstdint>
 
 class FileDescriptor
 {

--- a/src/util/mmap.hh
+++ b/src/util/mmap.hh
@@ -2,6 +2,7 @@
 #define MMAP_HH
 
 #include <sys/mman.h>
+#include <cstdint>
 
 class MMap
 {

--- a/src/util/serialization.hh
+++ b/src/util/serialization.hh
@@ -5,6 +5,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <cstdint>
 
 // convert values from network to host byte order
 inline uint8_t ntoh(uint8_t net) { return net; }

--- a/src/video/image.hh
+++ b/src/video/image.hh
@@ -6,6 +6,7 @@ extern "C" {
 }
 
 #include <string_view>
+#include <cstdint>
 
 // wrapper class for vpx_image of format I420
 class RawImage


### PR DESCRIPTION
This pull request addresses two issues:
1. Include `<cstdint>` for [GCC 13](https://gcc.gnu.org/gcc-13/porting_to.html) compatibility.
2. Changed the __maxevents argument passed to epoll_wait from the byte size of the array to the actual number of events in the array.